### PR TITLE
fix when model_params are empty

### DIFF
--- a/lib/standard_api/access_control_list.rb
+++ b/lib/standard_api/access_control_list.rb
@@ -56,7 +56,7 @@ module StandardAPI
     end
 
     def filter_model_params(model_params, model, id: nil, allow_id: nil)
-      permitted_params = if self.respond_to?("#{model_name(model)}_attributes", true)
+      permitted_params = if model_params && self.respond_to?("#{model_name(model)}_attributes", true)
         permits = self.send("#{model_name(model)}_attributes")
 
         allow_id ? model_params.permit(permits, :id) : model_params.permit(permits)

--- a/test/standard_api/standard_api_test.rb
+++ b/test/standard_api/standard_api_test.rb
@@ -92,9 +92,15 @@ class PropertiesControllerTest < ActionDispatch::IntegrationTest
     assert_equal @controller.send(:model_includes), []
   end
 
-  test 'Controller#model_params defaults to []' do
+  test 'Controller#model_params defaults to ActionController::Parameters' do
+    @controller = DocumentsController.new
+    @controller.params = ActionController::Parameters.new
+    assert_equal @controller.send(:model_params), ActionController::Parameters.new
+  end
+
+  test 'Controller#model_params defaults to ActionController::Parameters when no resource_attributes' do
     @controller = ReferencesController.new
-    @controller.params = {}
+    @controller.params = ActionController::Parameters.new
     assert_equal @controller.send(:model_params), ActionController::Parameters.new
   end
 


### PR DESCRIPTION
The following fails because there's no `survey` key in the body:
```
curl -H "Accept: application/json" -X POST http://localhost:3000/surveys 
```