### PR TITLE
update includes to include autosaved attributes

### DIFF
--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -257,7 +257,7 @@ module StandardAPI
         {}
       end
       if action_name == 'create' || action_name == 'update'
-        @includes = nested_includes(model, params.require(model.model_name.singular).to_unsafe_h).merge(@includes)
+        @includes = nested_includes(model, params[model.model_name.singular].to_unsafe_h).merge(@includes)
       end
       @includes
     end

--- a/test/standard_api/nested_attributes/has_many_test.rb
+++ b/test/standard_api/nested_attributes/has_many_test.rb
@@ -67,6 +67,19 @@ module NestedAttributes
       property.reload
       assert_equal [], property.accounts
     end
+    
+    test 'update record and include nested record in response' do
+      account = create(:account, name: 'A Co.')
+      property = create(:property, name: 'Empire State Building', accounts: [account])
+
+      @controller = PropertiesController.new
+      put property_path(property), params: { property: { name: 'John Hancock Center', accounts: [{id: account.id, name: "B Co."}]} }, as: :json
+
+      attributes = JSON.parse(response.body)
+      assert_response :ok
+      assert_equal account.id, attributes["accounts"][0]["id"]
+      assert_equal "B Co.", attributes["accounts"][0]["name"]
+    end
 
   end
 end


### PR DESCRIPTION
When saving a subresource standardapi should return that resource as something about it may have changed server side as a result of the save.

Example
```ruby
put property_path(property), params: {
  property: {
    name: 'John Hancock Center',
    accounts: [{
      id: account.id,
      name: "B Co."
    }]
  }
}, as: :json
```
Should return
```json
{
  "id": 91,
  "name": "John Hancock Center",
  "updated_at": "2021-12-09T14:30:52.944Z",
  "created_at": "2021-12-09T14:30:52.944Z"
  "accounts": [{
    "id": 22,
    "name": "B Co.",
    "name_last_changed_at": "2021-12-09T14:30:52.944Z",
    "updated_at": "2021-12-09T14:30:52.944Z",
    "created_at": "2021-12-09T14:30:52.944Z"
  }]
}
```

Note `name_last_changed_at`