### PR TITLE
add create_resource route and action to controller

### DIFF
--- a/lib/standard_api/route_helpers.rb
+++ b/lib/standard_api/route_helpers.rb
@@ -29,7 +29,7 @@ module StandardAPI
             [:index, :create, :show, :update, :destroy]
           else
             [:index, :create, :new, :show, :update, :destroy, :edit]
-          end + [ :schema, :calculate, :add_resource, :remove_resource ]
+          end + [ :schema, :calculate, :add_resource, :remove_resource, :create_resource ]
         end
 
         actions = if except = parent_resource.instance_variable_get(:@except)
@@ -43,6 +43,10 @@ module StandardAPI
 
         if actions.include?(:add_resource)
           post ':relationship/:resource_id' => :add_resource, on: :member
+        end
+        
+        if actions.include?(:create_resource)
+          post ':relationship' => :create_resource, on: :member
         end
 
         if actions.include?(:remove_resource)

--- a/test/standard_api/route_helpers_test.rb
+++ b/test/standard_api/route_helpers_test.rb
@@ -54,7 +54,10 @@ class RouteHelpersTest < ActionDispatch::IntegrationTest
       assert_routing({ path: '/photos/1', method: :patch }, { controller: 'photos', action: 'update', id: '1' })
       assert_routing({ path: '/photos/schema', method: :get }, { controller: 'photos', action: 'schema' })
       assert_routing({ path: '/photos/calculate', method: :get }, { controller: 'photos', action: 'calculate' })
-      assert_equal 11, set.routes.size
+      assert_routing({ path: '/photos/1/properties/1', method: :post }, { controller: 'photos', action: 'add_resource', id: '1', relationship: 'properties', resource_id: '1' })
+      assert_routing({ path: '/photos/1/properties/1', method: :delete }, { controller: 'photos', action: 'remove_resource', id: '1', relationship: 'properties', resource_id: '1' })
+      assert_routing({ path: '/photos/1/properties', method: :post }, { controller: 'photos', action: 'create_resource', id: '1', relationship: 'properties' })
+      assert_equal 12, set.routes.size
     end
   end
 

--- a/test/standard_api/standard_api_test.rb
+++ b/test/standard_api/standard_api_test.rb
@@ -196,6 +196,7 @@ class PropertiesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to document_path(pdf)
   end
 
+  # add_resource
   test 'Controller#add_resource with has_many' do
     property = create(:property, photos: [])
     photo = create(:photo)
@@ -240,6 +241,46 @@ class PropertiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  # create_resource
+  test 'Controller#create_resource with has_many' do
+    property = create(:property, photos: [])
+    photo = build(:photo)
+
+    post "/properties/#{property.id}/photos", params: { photo: photo.attributes }, as: :json
+    assert_equal property.photos.reload.map(&:id), [JSON.parse(response.body)['id']]
+    assert_equal property.photos.count, 1
+    assert_response :created
+  end
+
+  test 'Controller#create_resource with has_and_belongs_to_many' do
+    photo1 = create(:photo)
+    photo2 = build(:photo)
+    property = create(:property, photos: [photo1])
+
+    post "/properties/#{property.id}/photos", params: { photo: photo2.attributes }, as: :json
+    assert_equal property.photos.reload.map(&:id), [photo1.id, JSON.parse(response.body)['id']]
+    assert_equal property.photos.count, 2
+    assert_response :created
+  end
+
+  test 'Controller#create_resource with belongs_to' do
+    photo = create(:photo)
+    account = build(:account)
+
+    post "/photos/#{photo.id}/account", params: { account: account.attributes }, as: :json
+    assert_equal photo.reload.account_id, JSON.parse(response.body)['id']
+    assert_response :created
+  end
+
+  test 'Controller#create_resource with has_one' do
+    account = build(:account)
+    property = create(:property)
+    post "/properties/#{property.id}/landlord", params: { landlord: account.attributes }, as: :json
+    assert_equal property.reload.landlord.id, JSON.parse(response.body)['id']
+    assert_response :created
+  end
+
+  # remove_resource
   test 'Controller#remove_resource' do
     photo = create(:photo)
     property = create(:property, photos: [photo])


### PR DESCRIPTION
Support requests like this:

```ruby
post "properties/#{property.id}/floorplan", params: { file: 'x9hj0a90asdinoafxxx' }
assert_equal property.floorplan.id, JSON.parse(response.body)['id']
```