### PR TITLE
fix: custom routes take precedence over standardapi routes

### DIFF
--- a/lib/standard_api/route_helpers.rb
+++ b/lib/standard_api/route_helpers.rb
@@ -22,6 +22,8 @@ module StandardAPI
       options = resources.extract_options!.dup
 
       resources(*resources, options) do
+        block.call if block # custom routes take precedence over standardapi routes
+
         available_actions = if only = parent_resource.instance_variable_get(:@only)
           Array(only).map(&:to_sym)
         else
@@ -52,8 +54,6 @@ module StandardAPI
         if actions.include?(:remove_resource)
           delete ':relationship/:resource_id' => :remove_resource, on: :member
         end
-
-        block.call if block
       end
     end
 


### PR DESCRIPTION
```
# routes.rb
standard_resources :orders do
  post :my_custom_route
end
```

```
cfaruki@api[master !*] bundle e rails test test/controllers/orders_controller_test.rb
Run options: --seed 7265

# Running:

E

Error:
OrdersControllerTest#test_can_apply_credit_amount:
ActiveRecord::AssociationNotFoundError: Association named 'my_custom_route' was not found on Order; perhaps you misspelled it?
Did you mean?  payments
    activerecord (6.1.5.1) lib/active_record/associations.rb:313:in `association'
    standardapi (cd08e6d0661b) lib/standard_api/controller.rb:148:in `create_resource'
    actionpack (6.1.5.1) lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
```