### PR TITLE
update record.jbuilder to use records read method for attribute

### DIFF
--- a/lib/standard_api/views/application/_record.json.jbuilder
+++ b/lib/standard_api/views/application/_record.json.jbuilder
@@ -1,11 +1,11 @@
-record.attributes.each do |name, value|
+record.attribute_names.each do |name|
   # Skip if attribute is included in excludes
   next if defined?(excludes) && excludes[record.model_name.singular.to_sym].try(:find) { |x| x.to_s == name }
 
   if record.type_for_attribute(name).type == :binary
-    json.set! name, value&.unpack1('H*')
+    json.set! name, record.send(name)&.unpack1('H*')
   else
-    json.set! name, value
+    json.set! name, record.send(name)
   end
 end
 

--- a/lib/standard_api/views/application/_record.streamer
+++ b/lib/standard_api/views/application/_record.streamer
@@ -1,15 +1,15 @@
 json.object! do
 
-  record.attributes.each do |name, value|
-    # Skip if attribute is included in excludes
-    next if defined?(excludes) && excludes[record.model_name.singular.to_sym].try(:find) { |x| x.to_s == name }
+    record.attribute_names.each do |name|
+      # Skip if attribute is included in excludes
+      next if defined?(excludes) && excludes[record.model_name.singular.to_sym].try(:find) { |x| x.to_s == name }
 
-    if record.type_for_attribute(name).type == :binary
-      json.set! name, value&.unpack1('H*')
-    else
-      json.set! name, value
+      if record.type_for_attribute(name).type == :binary
+        json.set! name, record.send(name)&.unpack1('H*')
+      else
+        json.set! name, record.send(name)
+      end
     end
-  end
 
   includes.each do |inc, subinc|
     next if ["limit", "offset", "order", "when", "where", "distinct", "distinct_on"].include?(inc)

--- a/test/standard_api/caching_test.rb
+++ b/test/standard_api/caching_test.rb
@@ -32,8 +32,8 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     # Two associations that reference the same model
     property = create(:property)
     account = create(:account, property: property, subject: property)
-    Account.any_instance.expects(:property_cached_at).returns(t1)
-    Account.any_instance.expects(:subject_cached_at).returns(t1)
+    Account.any_instance.expects(:property_cached_at).twice.returns(t1)
+    Account.any_instance.expects(:subject_cached_at).twice.returns(t1)
     get account_path(account, include: { property: true, subject: true }, format: 'json')
     json = JSON(response.body)
     assert json.has_key?('property')


### PR DESCRIPTION
Support for

```ruby
class Expense < ApplicationRecord
  
  def amount
    self.read_attribute(:amount).try(:/, 100.0)
  end

end
```