### PR TITLE
New destroy options

### DIFF
--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -106,7 +106,8 @@ module StandardAPI
     end
 
     def destroy
-      ActiveRecord::Base.transaction { resources.find(params[:id].split(',')).each(&:destroy!) }
+      records = resources.find(params[:id].split(','))
+      ActiveRecord::Base.transaction { records.each(&:destroy!) }
 
       head :no_content
     end

--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -106,9 +106,7 @@ module StandardAPI
     end
 
     def destroy
-      resource_ids = if params[:id].include?('/')
-        params[:id].split('/')
-      elsif params[:id].include?(',')
+      resource_ids = if params[:id].include?(',')
         params[:id].split(',')
       else
         params[:id]

--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -106,7 +106,20 @@ module StandardAPI
     end
 
     def destroy
-      resources.find(params[:id]).destroy!
+      resource_ids = if params[:id].include?('/')
+        params[:id].split('/')
+      elsif params[:id].include?(',')
+        params[:id].split(',')
+      else
+        params[:id]
+      end
+      ActiveRecord::Base.transaction do
+        records = resources.where(id: resource_ids)
+        records.each do |record|
+          record.destroy!
+        end
+      end
+
       head :no_content
     end
 

--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -107,7 +107,7 @@ module StandardAPI
 
     def destroy
       records = resources.find(params[:id].split(','))
-      ActiveRecord::Base.transaction { records.each(&:destroy!) }
+      model.transaction { records.each(&:destroy!) }
 
       head :no_content
     end

--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -106,16 +106,12 @@ module StandardAPI
     end
 
     def destroy
-      resource_ids = if params[:id].include?(',')
-        params[:id].split(',')
-      else
-        params[:id]
-      end
-      ActiveRecord::Base.transaction do
-        records = resources.where(id: resource_ids)
-        records.each do |record|
-          record.destroy!
+      if params[:id].include?(',')
+        ActiveRecord::Base.transaction do
+          resources.where(id: params[:id].split(',')).each(&:destroy!)
         end
+      else
+        resources.find(params[:id]).destroy!
       end
 
       head :no_content

--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -106,13 +106,7 @@ module StandardAPI
     end
 
     def destroy
-      if params[:id].include?(',')
-        ActiveRecord::Base.transaction do
-          resources.where(id: params[:id].split(',')).each(&:destroy!)
-        end
-      else
-        resources.find(params[:id]).destroy!
-      end
+      ActiveRecord::Base.transaction { resources.find(params[:id].split(',')).each(&:destroy!) }
 
       head :no_content
     end

--- a/lib/standard_api/test_case/destroy_tests.rb
+++ b/lib/standard_api/test_case/destroy_tests.rb
@@ -31,18 +31,6 @@ module StandardAPI
         end
       end
 
-      test '#destroy.json with array of ids' do
-        m1 = create_model
-        m2 = create_model
-        m3 = create_model
-
-        assert_difference("#{model.name}.count", -3) do
-          delete resource_path(:destroy, id: [m1.id, m2.id, m3.id], format: :json)
-          assert_response :no_content
-          assert_equal '', response.body
-        end
-      end
-
       test '#destroy.json with array of comma separated ids' do
         m1 = create_model
         m2 = create_model

--- a/lib/standard_api/test_case/destroy_tests.rb
+++ b/lib/standard_api/test_case/destroy_tests.rb
@@ -31,6 +31,29 @@ module StandardAPI
         end
       end
 
+      test '#destroy.json with array of ids' do
+        m1 = create_model
+        m2 = create_model
+        m3 = create_model
+
+        assert_difference("#{model.name}.count", -3) do
+          delete resource_path(:destroy, id: [m1.id, m2.id, m3.id], format: :json)
+          assert_response :no_content
+          assert_equal '', response.body
+        end
+      end
+
+      test '#destroy.json with array of comma separated ids' do
+        m1 = create_model
+        m2 = create_model
+        m3 = create_model
+
+        assert_difference("#{model.name}.count", -3) do
+          delete resource_path(:destroy, id: "#{m1.id},#{m2.id},#{m3.id}", format: :json)
+          assert_response :no_content
+          assert_equal '', response.body
+        end
+      end
     end
   end
 end

--- a/lib/standard_api/test_case/destroy_tests.rb
+++ b/lib/standard_api/test_case/destroy_tests.rb
@@ -31,7 +31,7 @@ module StandardAPI
         end
       end
 
-      test '#destroy.json with array of comma separated ids' do
+      test '#destroy.json with comma separated ids' do
         m1 = create_model
         m2 = create_model
         m3 = create_model


### PR DESCRIPTION
What currently happens now is an array of ids is supplied, it is converted to a slash separated string:

"84/85" etc.

wrap in a transaction to ensure rollback behavior.

Test  that array of ids, or comma separated string is supported