### PR TITLE
add json_schema route and views for serving json schema response

### DIFF
--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -28,6 +28,10 @@ module StandardAPI
       def schema
         Rails.application.eager_load! if !Rails.application.config.eager_load
       end
+      
+      def json_schema
+        Rails.application.eager_load! if !Rails.application.config.eager_load
+      end
     end
 
     def index

--- a/lib/standard_api/helpers.rb
+++ b/lib/standard_api/helpers.rb
@@ -192,6 +192,48 @@ module StandardAPI
         'ewkb'
       end
     end
+    
+    # For JSON Schema
+    def json_column_schema(sql_type)
+      case sql_type
+      when 'binary', 'bytea'
+        # TODO contentMediaType correct?
+        # contentEncoding?
+        # https://json-schema.org/understanding-json-schema/reference/non_json_data
+        {type: 'string', contentMediaType: 'application/octet-stream'}
+      when 'duration'
+        {type: 'string', format: 'duration'}
+      when 'text'
+        {type: 'string'}
+      when 'json', 'jsonb'
+        {type: 'object'}
+      when 'smallint', 'bigint', 'integer'
+        {type: 'integer'}
+      when 'hstore'
+        # TODO contentMediaType? or contentEncoding?
+        {type: 'object'}
+      when 'datetime', /timestamp(\(\d+\))? without time zone/, 'time without time zone'
+        {type: 'string', format: 'date-time'}
+      when 'date'
+        {type: 'string', format: 'date'}
+      when /numeric(\(\d+(,\d+)?\))?/, 'double precision'
+        {type: 'number'} 
+      when 'inet'
+        # TODO contentMediaType? or contentEncoding?
+        {type: 'string'} 
+      when 'ltree'
+        # TODO contentMediaType? or contentEncoding?
+        {type: 'string'} 
+      when 'boolean'
+        {type: 'boolean'}
+      when 'uuid'
+        {type: 'string', format: 'uuid'}
+      when /character varying(\(\d+\))?/
+        {type: 'string'}
+      when /^geometry/
+        {type: 'string', contentMediaType: 'application/octet-stream'}
+      end
+    end
 
   end
 end

--- a/lib/standard_api/route_helpers.rb
+++ b/lib/standard_api/route_helpers.rb
@@ -20,7 +20,7 @@ module StandardAPI
     #   end
     def standard_resources(*resources, &block)
       options = resources.extract_options!.dup
-      standard_resource_actions = [ :schema, :calculate, :create_resource, :add_resource, :remove_resource ]
+      standard_resource_actions = [ :schema, :json_schema, :calculate, :create_resource, :add_resource, :remove_resource ]
 
       resources_options = options.deep_dup
 
@@ -50,6 +50,7 @@ module StandardAPI
         end
 
         get :schema, on: :collection if actions.include?(:schema)
+        get :json_schema, on: :collection if actions.include?(:json_schema)
         get :calculate, on: :collection if actions.include?(:calculate)
 
         if actions.include?(:add_resource)
@@ -94,7 +95,7 @@ module StandardAPI
             [:index, :create, :show, :update, :destroy]
           else
             [:index, :create, :new, :show, :update, :destroy, :edit]
-          end + [ :schema, :calculate, :add_resource, :remove_resource ]
+          end + [ :schema, :json_schema, :calculate, :add_resource, :remove_resource ]
         end
 
         actions = if except = parent_resource.instance_variable_get(:@except)
@@ -104,6 +105,7 @@ module StandardAPI
         end
 
         get :schema, on: :collection if actions.include?(:schema)
+        get :json_schema, on: :collection if actions.include?(:json_schema)
         get :calculate, on: :collection if actions.include?(:calculate)
 
         if actions.include?(:add_resource)

--- a/lib/standard_api/test_case/index_tests.rb
+++ b/lib/standard_api/test_case/index_tests.rb
@@ -57,6 +57,8 @@ module StandardAPI
 
         orders.each do |order|
           get resource_path(:index, format: :json), params: { limit: 10, order: order }
+          assert_response :ok
+          
           models = @controller.instance_variable_get("@#{plural_name}")
           assert_equal model.filter(mask).sort(order).limit(10).sort(order).to_sql, models.to_sql
         end

--- a/lib/standard_api/views/application/_json_schema.json.jbuilder
+++ b/lib/standard_api/views/application/_json_schema.json.jbuilder
@@ -1,0 +1,84 @@
+json.set! 'title', model.table_name.titleize.singularize
+json.set! 'type', 'object'
+if comment = model.connection.table_comment(model.table_name)
+  json.set! 'description', comment
+end
+json.set! 'properties' do
+  model.columns.each do |column|
+    column_schema = json_column_schema(column.sql_type)
+    
+    if controller.respond_to?("#{ model.model_name.singular }_attributes") && controller.send("#{ model.model_name.singular }_attributes").map(&:to_s).exclude?(column.name)
+      column_schema[:readOnly] = true
+    elsif column.respond_to?(:auto_populated?) && !!column.auto_populated?
+      column_schema[:readOnly] = true
+    end
+    
+    if default = column.default ? model.connection.lookup_cast_type_from_column(column).deserialize(column.default) : nil
+      column_schema[:default] = default
+    end
+    
+    if column.comment
+      column_schema[:description] = column.comment
+    end
+    
+    if column.null == false
+      column_schema[:required] = true
+    end
+    
+    if model.type_for_attribute(column.name).is_a?(::ActiveRecord::Enum::EnumType)
+      column_schema[:default] = model.defined_enums[column.name].key(default)
+      column_schema[:type] = 'string'
+    end
+
+    model.validators.select { |v| v.attributes.include?(column.name.to_sym) }.each do |v|
+      case v
+      when ::ActiveRecord::Validations::NumericalityValidator
+        column_schema["exclusiveMinimum"] = v.options[:greater_than] if v.options[:greater_than]
+        column_schema["exclusiveMaximum"] = v.options[:less_than] if v.options[:less_than]
+        column_schema["minimum"] = v.options[:greater_than_or_equal_to] if v.options[:greater_than_or_equal_to]
+        column_schema["maximum"] = v.options[:less_than_or_equal_to] if v.options[:less_than_or_equal_to]
+      when ::ActiveModel::Validations::InclusionValidator
+        column_schema["enum"] = v.options[:in] if v.options[:in]
+      when ::ActiveModel::Validations::AcceptanceValidator
+        column_schema["const"] = true
+        column_schema["required"] = true if v.options[:allow_nil] != true
+      when ::ActiveModel::Validations::FormatValidator
+        column_schema["pattern"] = v.options[:with] if v.options[:with]
+      when ::ActiveModel::Validations::LengthValidator
+        column_schema["minLength"] = v.options[:minimum] if v.options[:minimum]
+        column_schema["maxLength"] = v.options[:maximum] if v.options[:maximum]
+      when ::ActiveModel::Validations::PresenceValidator
+        column_schema["required"] = true
+      else
+        puts "******* MISSING VALIDATOR **********"
+        puts v.inspect
+        warn "missing validator"
+      end
+    end
+
+    json.set! column.name do
+      if column.array
+        json.set! 'type', 'array'
+        json.set! 'items', column_schema
+      else
+        json.merge! column_schema
+      end
+    end
+  end
+end
+
+includes.each do |inc, subinc|
+  case association = model.reflect_on_association(inc)
+  when ::ActiveRecord::Reflection::AbstractReflection
+    json.set! inc do
+      if association.collection?
+        json.set! 'type', 'array'
+        json.set! 'items' do
+          json.partial!('json_schema', model: association.klass, includes: subinc)
+        end
+      else
+        json.partial!('json_schema', model: association.klass, includes: subinc)
+      end
+    end
+  end
+end

--- a/lib/standard_api/views/application/_json_schema.streamer
+++ b/lib/standard_api/views/application/_json_schema.streamer
@@ -1,0 +1,94 @@
+json.object! do
+  json.set! 'title', model.table_name.titleize.singularize
+  json.set! 'type', 'object'
+  if comment = model.connection.table_comment(model.table_name)
+    json.set! 'description', comment
+  end
+  json.set! 'properties' do
+    json.object! do
+      model.columns.each do |column|
+        column_schema = json_column_schema(column.sql_type)
+        
+        if controller.respond_to?("#{ model.model_name.singular }_attributes") && controller.send("#{ model.model_name.singular }_attributes").map(&:to_s).exclude?(column.name)
+          column_schema[:readOnly] = true
+        elsif column.respond_to?(:auto_populated?) && !!column.auto_populated?
+          column_schema[:readOnly] = true
+        end
+        
+        if default = column.default ? model.connection.lookup_cast_type_from_column(column).deserialize(column.default) : nil
+          column_schema[:default] = default
+        end
+        
+        if column.comment
+          column_schema[:description] = column.comment
+        end
+        
+        if column.null == false
+          column_schema[:required] = true
+        end
+        
+        if model.type_for_attribute(column.name).is_a?(::ActiveRecord::Enum::EnumType)
+          column_schema[:default] = model.defined_enums[column.name].key(default)
+          column_schema[:type] = 'string'
+        end
+
+        model.validators.select { |v| v.attributes.include?(column.name.to_sym) }.each do |v|
+          case v
+          when ::ActiveRecord::Validations::NumericalityValidator
+            column_schema["exclusiveMinimum"] = v.options[:greater_than] if v.options[:greater_than]
+            column_schema["exclusiveMaximum"] = v.options[:less_than] if v.options[:less_than]
+            column_schema["minimum"] = v.options[:greater_than_or_equal_to] if v.options[:greater_than_or_equal_to]
+            column_schema["maximum"] = v.options[:less_than_or_equal_to] if v.options[:less_than_or_equal_to]
+          when ::ActiveModel::Validations::InclusionValidator
+            column_schema["enum"] = v.options[:in] if v.options[:in]
+          when ::ActiveModel::Validations::AcceptanceValidator
+            column_schema["const"] = true
+            column_schema["required"] = true if v.options[:allow_nil] != true
+          when ::ActiveModel::Validations::FormatValidator
+            column_schema["pattern"] = v.options[:with] if v.options[:with]
+          when ::ActiveModel::Validations::LengthValidator
+            column_schema["minLength"] = v.options[:minimum] if v.options[:minimum]
+            column_schema["maxLength"] = v.options[:maximum] if v.options[:maximum]
+          when ::ActiveModel::Validations::PresenceValidator
+            column_schema["required"] = true
+          else
+            puts "******* MISSING VALIDATOR **********"
+            puts v.inspect
+            warn "missing validator"
+          end
+        end
+
+        json.set! column.name do
+          json.object! do
+            if column.array
+              json.set! 'type', 'array'
+              json.set! 'items', column_schema
+            else
+              json.merge! column_schema
+            end
+          end
+        end
+      end
+    end
+  end
+  
+  includes.each do |inc, subinc|
+    case association = model.reflect_on_association(inc)
+    when ::ActiveRecord::Reflection::AbstractReflection
+      json.set! inc do
+        if association.collection?
+          json.object! do
+            json.set! 'type', 'array'
+            json.set! 'items' do
+              json.partial!('json_schema', model: association.klass, includes: subinc)
+            end
+          end
+        else
+          json.object! do
+            json.partial!('json_schema', model: association.klass, includes: subinc)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/standard_api/views/application/json_schema.json.jbuilder
+++ b/lib/standard_api/views/application/json_schema.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial!('json_schema', model: model, includes: includes)

--- a/lib/standard_api/views/application/json_schema.streamer
+++ b/lib/standard_api/views/application/json_schema.streamer
@@ -1,0 +1,1 @@
+json.partial!('json_schema', model: model, includes: includes)

--- a/test/standard_api/json_schema_test.rb
+++ b/test/standard_api/json_schema_test.rb
@@ -1,0 +1,125 @@
+require 'standard_api/test_helper'
+
+class JSONSchemaTest < ActionDispatch::IntegrationTest
+  
+  test 'Controller#json_schema.json' do
+    get json_schema_references_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal true, schema.has_key?('properties')
+    assert_equal true, schema['properties']['id']['required']
+  end
+  
+  test 'Controller#json_schema.json table description' do
+    get json_schema_documents_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal 'I <3 Documents', schema['description']
+  end
+  
+  test 'Controller#json_schema.json default' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal 2, schema.dig('properties', 'numericality', 'default')
+  end
+  
+  test 'Controller#json_schema.json required' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal true, schema.dig('properties', 'name', 'required')
+    assert_equal nil, schema.dig('properties', 'description', 'required')
+  end
+  
+  test 'Controller#json_schema.json readOnly' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal true, schema.dig('properties', 'created_at', 'readOnly')
+    assert_equal nil, schema.dig('properties', 'name', 'readOnly')
+  end
+  
+  test 'Controller#json_schema.json type' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal 'string', schema.dig('properties', 'created_at', 'type')
+    assert_equal 'date-time', schema.dig('properties', 'created_at', 'format')
+  end
+  
+  test 'Controller#json_schema.json array' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal 'array', schema.dig('properties', 'aliases', 'type')
+    assert_equal 'string', schema.dig('properties', 'aliases', 'items', 'type')
+  end
+  
+  test 'Controller#json_schema.json validation:numericality' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal 1, schema.dig('properties', 'numericality', 'exclusiveMinimum')
+    assert_equal 2, schema.dig('properties', 'numericality', 'minimum')
+    assert_equal 2, schema.dig('properties', 'numericality', 'maximum')
+    assert_equal 3, schema.dig('properties', 'numericality', 'exclusiveMaximum')
+  end
+  
+  test 'Controller#json_schema.json validation:inclusion' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal ['concrete', 'metal', 'brick'], schema.dig('properties', 'build_type', 'enum')
+  end
+  
+  test 'Controller#json_schema.json validation:acceptance' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal true, schema.dig('properties', 'agree_to_terms', 'const')
+  end
+  
+  test 'Controller#json_schema.json validation:format' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal "(?-mix:\\d{3}-\\d{3}-\\d{4})", schema.dig('properties', 'phone_number', 'pattern')
+  end
+  
+  test 'Controller#json_schema.json validation:length' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal 9, schema.dig('properties', 'phone_number', 'minLength')
+    assert_equal 12, schema.dig('properties', 'phone_number', 'maxLength')
+  end
+  
+  test 'Controller#json_schema.json validation:presence' do
+    get json_schema_properties_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal true, schema.dig('properties', 'name', 'required')
+  end
+
+
+  test 'Controller#json_schema.json for an enum with default' do
+    get json_schema_documents_path(format: 'json')
+
+    schema = JSON(response.body)
+    assert_equal true, schema.has_key?('properties')
+    assert_equal 'string', schema['properties']['level']['type']
+    assert_equal 'public', schema['properties']['level']['default']
+  end
+  
+  test 'Controller#json_schema.json for an enum without default' do
+    get json_schema_documents_path(format: 'json')
+
+    schema = JSON(response.body)
+
+    assert_equal true, schema.has_key?('properties')
+    assert_equal 'string', schema['properties']['rating']['type']
+    assert_nil schema['properties']['rating']['default']
+  end
+
+end

--- a/test/standard_api/route_helpers_test.rb
+++ b/test/standard_api/route_helpers_test.rb
@@ -61,11 +61,12 @@ class RouteHelpersTest < ActionDispatch::IntegrationTest
       assert_routing({ path: '/photos/1', method: :put }, { controller: 'photos', action: 'update', id: '1' })
       assert_routing({ path: '/photos/1', method: :patch }, { controller: 'photos', action: 'update', id: '1' })
       assert_routing({ path: '/photos/schema', method: :get }, { controller: 'photos', action: 'schema' })
+      assert_routing({ path: '/photos/json_schema', method: :get }, { controller: 'photos', action: 'json_schema' })
       assert_routing({ path: '/photos/calculate', method: :get }, { controller: 'photos', action: 'calculate' })
       assert_routing({ path: '/photos/1/properties/1', method: :post }, { controller: 'photos', action: 'add_resource', id: '1', relationship: 'properties', resource_id: '1' })
       assert_routing({ path: '/photos/1/properties/1', method: :delete }, { controller: 'photos', action: 'remove_resource', id: '1', relationship: 'properties', resource_id: '1' })
       assert_routing({ path: '/photos/1/properties', method: :post }, { controller: 'photos', action: 'create_resource', id: '1', relationship: 'properties' })
-      assert_equal 12, set.routes.size
+      assert_equal 13, set.routes.size
     end
   end
 
@@ -90,8 +91,9 @@ class RouteHelpersTest < ActionDispatch::IntegrationTest
       assert_routing({ path: '/accounts', method: :put }, { controller: 'accounts', action: 'update' })
       assert_routing({ path: '/accounts', method: :patch }, { controller: 'accounts', action: 'update' })
       assert_routing({ path: '/accounts/schema', method: :get }, { controller: 'accounts', action: 'schema' })
+      assert_routing({ path: '/accounts/json_schema', method: :get }, { controller: 'accounts', action: 'json_schema' })
       assert_routing({ path: '/accounts/calculate', method: :get }, { controller: 'accounts', action: 'calculate' })
-      assert_equal 10, set.routes.size
+      assert_equal 11, set.routes.size
     end
   end
 end

--- a/test/standard_api/test_app/app/controllers/acl/property_acl.rb
+++ b/test/standard_api/test_app/app/controllers/acl/property_acl.rb
@@ -25,7 +25,10 @@ module PropertyACL
       "size",
       "created_at",
       "active",
-      "numericality"
+      "numericality",
+      "build_type",
+      "phone_number",
+      "agree_to_terms"
     ]
   end
 

--- a/test/standard_api/test_app/models.rb
+++ b/test/standard_api/test_app/models.rb
@@ -30,7 +30,6 @@ class Property < ActiveRecord::Base
   has_one :document_attachments, class_name: "Attachment", as: :record, inverse_of: :record
   has_one :document, through: "document_attachments"
 
-  validates :name, presence: true
   accepts_nested_attributes_for :photos
 
   def english_name
@@ -48,6 +47,11 @@ class Property < ActiveRecord::Base
     even: true,
     in: 1..3
   }
+
+  validates :name, presence: true
+  validates :build_type, inclusion: {in: ['concrete', 'metal', 'brick'], allow_nil: true}
+  validates :agree_to_terms, acceptance: true
+  validates :phone_number, format: /\d{3}-\d{3}-\d{4}/, length: {minimum: 9, maximum: 12, allow_blank: true}
   
 end
 
@@ -144,6 +148,9 @@ class CreateModelTables < ActiveRecord::Migration[6.0]
       t.datetime "created_at",                         null: false
       t.boolean  "active",             default: false
       t.integer  "numericality",       default: 2
+      t.string   "build_type"
+      t.boolean  "agree_to_terms", default: true
+      t.string  "phone_number", default: '999-999-9999'
     end
 
     create_table "references", force: :cascade do |t|
@@ -166,9 +173,9 @@ class CreateModelTables < ActiveRecord::Migration[6.0]
       t.integer  "property_id"
     end
 
-    create_table "documents", force: :cascade do |t|
+    create_table "documents", force: :cascade, comment: 'I <3 Documents' do |t|
       t.integer  'level', limit: 2, null: false, default: 0
-      t.integer  'rating', limit: 2
+      t.integer  'rating', limit: 2, comment: 'Ratings are 1-10, where 10 is great'
       t.string   'type'
     end
 


### PR DESCRIPTION
Add a new route for requesting schema of a resource that follows [JSON Schema Spec](https://json-schema.org)

```json
{
    "properties": {
        "size": {
            "type": "number",
            "description": "The overall size of the interior space expresszed in object's size_units",
            "default": null,
            "required": false,
            "minimum": 0

        },
        "size_units": {
            "type": "string",
            "description": "The units of measurement for size",
            "default": "sqft",
            "required": true,
            "enum": [
                "sqin",
                "sqft",
                "sqm",
                "tsubo",
                "ac",
                "ac"
            ]
        }
    }
}
```

Limitations of JSON Schema to note:
---
- Only supported types: array, boolean, null, number, integer, string, object
- There are some options to provide formatting of strings, like "date-time"
- There is not support for validations, but there are some describing attributes like `minLength` that can be provided by Rails validations
- `enum` is a list of allowable values