### PR TITLE
JSON Schema Includes

### DIFF
--- a/lib/standard_api/access_control_list.rb
+++ b/lib/standard_api/access_control_list.rb
@@ -87,24 +87,22 @@ module StandardAPI
               permitted_params[attributes_key] = if model_params[attributes_key].is_a?(Array)
                 models = association.klass.find(model_params[attributes_key].map { |i| i['id'] }.compact)
                 model_params[attributes_key].map { |i|
-                  i_params = self.send(filter_method, i, allow_id: true)
-                  if i_params['id']
-                    r = models.find { |r| r.id == i_params['id'] }
-                    r.assign_attributes(i_params)
-                    r
+                  r = if i_params['id']
+                    models.find { |r| r.id == i_params['id'] }
                   else
-                    association.klass.new(i_params)
+                    association.klass.new
                   end
+                  i_params = self.send(filter_method, r, i, allow_id: true)
+                  r.assign_attributes(i_params)
                 }
               else
-                i_params = self.send(filter_method, model_params[attributes_key], allow_id: true)
-                if i_params['id']
-                  r = association.klass.find(i_params['id'])
-                  r.assign_attributes(i_params)
-                  r
+                r = if i_params['id']
+                  association.klass.find(i_params['id'])
                 else
-                  association.klass.new(i_params)
+                  association.klass.new()
                 end
+                i_params = self.send(filter_method, r, model_params[attributes_key], allow_id: true)
+                r.assign_attributes(i_params)
               end
             else
               permitted_params[attributes_key] = if model_params[attributes_key].is_a?(Array)

--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -7,7 +7,7 @@ module StandardAPI
       klass.helper_method :includes, :orders, :model, :models, :resource_limit,
         :default_limit
       klass.before_action :set_standardapi_headers
-      klass.before_action :includes, except: [:destroy, :add_resource, :remove_resource]
+      klass.before_action :includes, except: [:destroy, :add_resource, :remove_resource, :json_schema]
       klass.rescue_from StandardAPI::ParameterMissing, with: :bad_request
       klass.rescue_from StandardAPI::UnpermittedParameters, with: :bad_request
       klass.append_view_path(File.join(File.dirname(__FILE__), 'views'))
@@ -28,10 +28,11 @@ module StandardAPI
       def schema
         Rails.application.eager_load! if !Rails.application.config.eager_load
       end
-      
-      def json_schema
-        Rails.application.eager_load! if !Rails.application.config.eager_load
-      end
+    end
+    
+    def json_schema
+      Rails.application.eager_load! if !Rails.application.config.eager_load
+      @includes = StandardAPI::Includes.normalize(params[:include] || {})
     end
 
     def index

--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -156,9 +156,9 @@ module StandardAPI
     def create_resource
       resource = resources.find(params[:id])
       association = resource.association(params[:relationship])
-
+      subresource = association.klass.new
       subresource_params = if self.respond_to?("filter_#{model_name(association.klass)}_params", true)
-        self.send("filter_#{model_name(association.klass)}_params", params[model_name(association.klass)], id: params[:id])
+        self.send("filter_#{model_name(association.klass)}_params", subresource, params[model_name(association.klass)], id: params[:id])
       elsif self.respond_to?("#{association.klass.model_name.singular}_params", true)
         params.require(association.klass.model_name.singular).permit(self.send("#{association.klass.model_name.singular}_params"))
       elsif self.respond_to?("filter_model_params", true)
@@ -167,7 +167,7 @@ module StandardAPI
         ActionController::Parameters.new
       end
 
-      subresource = association.klass.new(subresource_params)
+      subresource.assign_attributes(subresource_params)
 
       result = case association
       when ::ActiveRecord::Associations::CollectionAssociation

--- a/lib/standard_api/views/application/_json_schema.streamer
+++ b/lib/standard_api/views/application/_json_schema.streamer
@@ -7,6 +7,8 @@ json.object! do
   json.set! 'properties' do
     json.object! do
       model.columns.each do |column|
+        next if includes["only"]&.exclude?(column.name)
+        next if includes["except"]&.include?(column.name)
         column_schema = json_column_schema(column.sql_type)
         
         if controller.respond_to?("#{ model.model_name.singular }_attributes") && controller.send("#{ model.model_name.singular }_attributes").map(&:to_s).exclude?(column.name)
@@ -69,23 +71,23 @@ json.object! do
           end
         end
       end
-    end
-  end
-  
-  includes.each do |inc, subinc|
-    case association = model.reflect_on_association(inc)
-    when ::ActiveRecord::Reflection::AbstractReflection
-      json.set! inc do
-        if association.collection?
-          json.object! do
-            json.set! 'type', 'array'
-            json.set! 'items' do
+      includes.each do |inc, subinc|
+        next if %w(only except).include?(inc)
+        next if includes["only"]&.exclude?(inc)
+        next if includes["except"]&.include?(inc)
+        case association = model.reflect_on_association(inc)
+        when ::ActiveRecord::Reflection::AbstractReflection
+          json.set! inc do
+            if association.collection?
+              json.object! do
+                json.set! 'type', 'array'
+                json.set! 'items' do
+                  json.partial!('json_schema', model: association.klass, includes: subinc)
+                end
+              end
+            else
               json.partial!('json_schema', model: association.klass, includes: subinc)
             end
-          end
-        else
-          json.object! do
-            json.partial!('json_schema', model: association.klass, includes: subinc)
           end
         end
       end

--- a/lib/standard_api/views/application/_json_schema.streamer
+++ b/lib/standard_api/views/application/_json_schema.streamer
@@ -1,4 +1,5 @@
 json.object! do
+  required = Set.new
   json.set! 'title', model.table_name.titleize.singularize
   json.set! 'type', 'object'
   if comment = model.connection.table_comment(model.table_name)
@@ -25,8 +26,8 @@ json.object! do
           column_schema[:description] = column.comment
         end
         
-        if column.null == false
-          column_schema[:required] = true
+        if column.null == false && column_schema[:readOnly] != true
+          required.add(column.name)
         end
         
         if model.type_for_attribute(column.name).is_a?(::ActiveRecord::Enum::EnumType)
@@ -45,14 +46,14 @@ json.object! do
             column_schema["enum"] = v.options[:in] if v.options[:in]
           when ::ActiveModel::Validations::AcceptanceValidator
             column_schema["const"] = true
-            column_schema["required"] = true if v.options[:allow_nil] != true
+            required.add(column.name) if v.options[:allow_nil] != true
           when ::ActiveModel::Validations::FormatValidator
             column_schema["pattern"] = v.options[:with] if v.options[:with]
           when ::ActiveModel::Validations::LengthValidator
             column_schema["minLength"] = v.options[:minimum] if v.options[:minimum]
             column_schema["maxLength"] = v.options[:maximum] if v.options[:maximum]
           when ::ActiveModel::Validations::PresenceValidator
-            column_schema["required"] = true
+            required.add(column.name)
           else
             puts "******* MISSING VALIDATOR **********"
             puts v.inspect
@@ -93,4 +94,5 @@ json.object! do
       end
     end
   end
+  json.set! 'required', required.to_a
 end

--- a/lib/standard_api/views/application/json_schema.json.jbuilder
+++ b/lib/standard_api/views/application/json_schema.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial!('json_schema', model: model, includes: includes)
+json.partial!('json_schema', model: model, includes: @includes)

--- a/lib/standard_api/views/application/json_schema.streamer
+++ b/lib/standard_api/views/application/json_schema.streamer
@@ -1,1 +1,1 @@
-json.partial!('json_schema', model: model, includes: includes)
+json.partial!('json_schema', model: model, includes: @includes)

--- a/test/standard_api/json_schema_test.rb
+++ b/test/standard_api/json_schema_test.rb
@@ -121,5 +121,35 @@ class JSONSchemaTest < ActionDispatch::IntegrationTest
     assert_equal 'string', schema['properties']['rating']['type']
     assert_nil schema['properties']['rating']['default']
   end
+  
+  test 'Controller#json_schema.json include only' do
+    get json_schema_properties_path(format: 'json'), params: { include: {only: ['created_at']} }
+    
+    schema = JSON(response.body)
+    assert_equal ['created_at'], schema['properties'].keys
+  end
+  
+  test 'Controller#json_schema.json include except' do
+    get json_schema_properties_path(format: 'json'), params: { include: {except: ['created_at']} }
+    
+    schema = JSON(response.body)
+    assert schema['properties'].keys.exclude?('created_at')
+  end
+  
+  test 'Controller#json_schema.json include has_many' do
+    get json_schema_properties_path(format: 'json'), params: { include: 'accounts' }
+    
+    schema = JSON(response.body)
+    assert_equal 'array', schema.dig('properties', 'accounts', 'type')
+    assert_equal 'string', schema.dig('properties', 'accounts', 'items', 'properties', 'email', 'type')
+  end
+
+  test 'Controller#json_schema.json include belongs_to' do
+    get json_schema_photos_path(format: 'json'), params: { include: 'account' }
+
+    schema = JSON(response.body)
+    assert_equal 'object', schema.dig('properties', 'account', 'type')
+    assert_equal 'string', schema.dig('properties', 'account', 'properties', 'email', 'type')
+  end
 
 end

--- a/test/standard_api/json_schema_test.rb
+++ b/test/standard_api/json_schema_test.rb
@@ -3,11 +3,11 @@ require 'standard_api/test_helper'
 class JSONSchemaTest < ActionDispatch::IntegrationTest
   
   test 'Controller#json_schema.json' do
-    get json_schema_references_path(format: 'json')
+    get json_schema_cameras_path(format: 'json')
 
     schema = JSON(response.body)
     assert_equal true, schema.has_key?('properties')
-    assert_equal true, schema['properties']['id']['required']
+    assert_equal true, schema['required'].include?('make')
   end
   
   test 'Controller#json_schema.json table description' do
@@ -28,8 +28,8 @@ class JSONSchemaTest < ActionDispatch::IntegrationTest
     get json_schema_properties_path(format: 'json')
 
     schema = JSON(response.body)
-    assert_equal true, schema.dig('properties', 'name', 'required')
-    assert_equal nil, schema.dig('properties', 'description', 'required')
+    assert_equal true, schema['required'].include?('name')
+    assert_equal true, schema['required'].exclude?('description')
   end
   
   test 'Controller#json_schema.json readOnly' do
@@ -99,7 +99,7 @@ class JSONSchemaTest < ActionDispatch::IntegrationTest
     get json_schema_properties_path(format: 'json')
 
     schema = JSON(response.body)
-    assert_equal true, schema.dig('properties', 'name', 'required')
+    assert_equal true, schema['required'].include?('name')
   end
 
 

--- a/test/standard_api/standard_api_test.rb
+++ b/test/standard_api/standard_api_test.rb
@@ -304,7 +304,7 @@ class PropertiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     # assert_equal ['properties', 'accounts', 'photos', 'references', 'sessions', 'unlimited'], response.parsed_body
     # Multiple 'accounts' because multiple controllers with that model for testing.
-    assert_equal ["properties", "accounts", "documents", "photos", "references", "accounts", 'accounts', 'uuid_models'].sort, response.parsed_body.sort
+    assert_equal ["properties", "accounts", "cameras", "documents", "photos", "references", "accounts", 'accounts', 'uuid_models'].sort, response.parsed_body.sort
   end
 
   test 'rendering null attribute' do

--- a/test/standard_api/test_app.rb
+++ b/test/standard_api/test_app.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
   get :tables, to: 'application#tables', as: :tables
   get :schema, to: 'application#schema', as: :schema
 
-  [:properties, :photos, :documents, :references, :sessions, :unlimited, :default_limit].each do |r|
+  [:properties, :photos, :documents, :references, :sessions, :unlimited, :default_limit, :cameras].each do |r|
     standard_resources r
   end
 

--- a/test/standard_api/test_app/controllers.rb
+++ b/test/standard_api/test_app/controllers.rb
@@ -94,3 +94,6 @@ end
 
 class UuidModelController < ApplicationController
 end
+
+class CamerasController < ApplicationController
+end

--- a/test/standard_api/test_app/models.rb
+++ b/test/standard_api/test_app/models.rb
@@ -182,7 +182,7 @@ class CreateModelTables < ActiveRecord::Migration[6.0]
 
     create_table "cameras", force: :cascade do |t|
       t.integer  'photo_id'
-      t.string   'make'
+      t.string   'make', null: false
     end
 
     create_table "attachments", force: :cascade do |t|


### PR DESCRIPTION
Partial support for this was included in json-schema PR

This PR moves keys, fixes non-collection associations, and adds support for only and except (follows name convention of Rails [as_json](https://api.rubyonrails.org/classes/ActiveModel/Serializers/JSON.html#method-i-as_json))