### PR TITLE
Add Rails 8.2 (main) compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,12 @@ jobs:
           - 7.2.2.1
           - 8.0.4
           - 8.1.2
+          - main
         postgres-version:
           - 15
+        exclude:
+          - ruby-version: 3.2
+            rails-version: main
 
     steps:
       - name: Install Postgresql
@@ -53,7 +57,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - run: |
-          echo 'gem "rails", "${{ matrix.rails-version }}"' >> Gemfile
+          if [ "${{ matrix.rails-version }}" = "main" ]; then
+            echo 'gem "rails", github: "rails/rails", branch: "main"' >> Gemfile
+          else
+            echo 'gem "rails", "${{ matrix.rails-version }}"' >> Gemfile
+          fi
           echo 'gem "wankel"' >> Gemfile
 
       - uses: ruby/setup-ruby@v1

--- a/lib/standard_api/controller.rb
+++ b/lib/standard_api/controller.rb
@@ -7,7 +7,7 @@ module StandardAPI
       klass.helper_method :includes, :orders, :model, :models, :resource_limit,
         :default_limit
       klass.before_action :set_standardapi_headers
-      klass.before_action :includes, except: [:destroy, :add_resource, :remove_resource, :json_schema]
+      klass.before_action :includes, only: [:create, :update, :create_resource]
 
       klass.rescue_from StandardAPI::ParameterMissing, with: :bad_request
       klass.rescue_from StandardAPI::UnpermittedParameters, with: :bad_request

--- a/lib/standard_api/helpers.rb
+++ b/lib/standard_api/helpers.rb
@@ -4,7 +4,15 @@ module StandardAPI
     def serialize_attribute(json, record, name, type)
       value = record.send(name)
 
-      json.set! name, type == :binary ? value&.unpack1('H*') : value
+      value = if type == :binary
+        value&.unpack1('H*')
+      elsif value.is_a?(BigDecimal)
+        value.to_s
+      else
+        value
+      end
+
+      json.set! name, value
     end
 
     def preloadables(record, includes)

--- a/lib/standard_api/railtie.rb
+++ b/lib/standard_api/railtie.rb
@@ -11,11 +11,11 @@ module StandardAPI
       end
 
       ActiveSupport.on_load(:before_configuration) do
-        ::ActionDispatch::Routing::Mapper.send :include, StandardAPI::RouteHelpers
+        ::ActionDispatch::Routing::Mapper.include StandardAPI::RouteHelpers
       end
 
       ActiveSupport.on_load(:action_view) do
-        ::ActionView::Base.send :include, StandardAPI::Helpers
+        ::ActionView::Base.include StandardAPI::Helpers
       end
     end
 

--- a/lib/standard_api/test_case.rb
+++ b/lib/standard_api/test_case.rb
@@ -10,6 +10,7 @@ require File.expand_path(File.join(__FILE__, '../test_case/show_tests'))
 require File.expand_path(File.join(__FILE__, '../test_case/update_tests'))
 
 module StandardAPI::TestCase
+  include StandardAPI::Helpers
 
   def assert_equal_or_nil(expected, *args)
     if expected.nil?

--- a/lib/standard_api/test_case/schema_tests.rb
+++ b/lib/standard_api/test_case/schema_tests.rb
@@ -20,7 +20,7 @@ module StandardAPI
           assert_equal_or_nil column.comment, actual_column['comment']
 
           if !column.default.nil?
-            default = column.fetch_cast_type(model.connection).deserialize(column.default)
+            default = column_default_value(column, model)
             assert_equal default, actual_column['default']
           else
             assert_nil actual_column['default']

--- a/lib/standard_api/version.rb
+++ b/lib/standard_api/version.rb
@@ -1,3 +1,3 @@
 module StandardAPI
-  VERSION = '8.1.0'
+  VERSION = '8.2.0'
 end

--- a/lib/standard_api/views/application/_json_schema.json.jbuilder
+++ b/lib/standard_api/views/application/_json_schema.json.jbuilder
@@ -16,7 +16,7 @@ json.set! 'properties' do
       column_schema[:readOnly] = true
     end
     
-    if default = !column.default.nil? ? column.fetch_cast_type(model.connection).deserialize(column.default) : nil
+    if default = column_default_value(column, model)
       column_schema[:default] = default
     end
     

--- a/lib/standard_api/views/application/_json_schema.streamer
+++ b/lib/standard_api/views/application/_json_schema.streamer
@@ -18,7 +18,7 @@ json.object! do
           column_schema[:readOnly] = true
         end
         
-        if default = !column.default.nil? ? column.fetch_cast_type(model.connection).deserialize(column.default) : nil
+        if default = column_default_value(column, model)
           column_schema[:default] = default
         end
         

--- a/lib/standard_api/views/application/_schema.json.jbuilder
+++ b/lib/standard_api/views/application/_schema.json.jbuilder
@@ -16,7 +16,7 @@ if model.nil? && controller_name == "application"
         begin
           controller_param = controller_name.underscore
           const_name = "#{controller_param.camelize}Controller"
-          const = ActiveSupport::Dependencies.constantize(const_name)
+          const = const_name.constantize
           if const.ancestors.include?(StandardAPI::Controller)
             const
           else
@@ -50,7 +50,7 @@ else
 
   json.set! 'attributes' do
     model.columns.each do |column|
-      default = !column.default.nil? ? column.fetch_cast_type(model.connection).deserialize(column.default) : nil
+      default = column_default_value(column, model)
       type = case model.type_for_attribute(column.name)
       when ::ActiveRecord::Enum::EnumType
         default = model.defined_enums[column.name].key(default)

--- a/lib/standard_api/views/application/_schema.streamer
+++ b/lib/standard_api/views/application/_schema.streamer
@@ -17,7 +17,7 @@ if model.nil? && controller_name == "application"
           begin
             controller_param = controller_name.underscore
             const_name = "#{controller_param.camelize}Controller"
-            const = ActiveSupport::Dependencies.constantize(const_name)
+            const = const_name.constantize
             if const.ancestors.include?(StandardAPI::Controller)
               const
             else
@@ -59,7 +59,7 @@ else
     json.set! 'attributes' do
       json.object! do
         model.columns.each do |column|
-          default = !column.default.nil? ? column.fetch_cast_type(model.connection).deserialize(column.default) : nil
+          default = column_default_value(column, model)
           type = case model.type_for_attribute(column.name)
           when ::ActiveRecord::Enum::EnumType
             default = model.defined_enums[column.name].key(default)

--- a/test/standard_api/controller/include_test.rb
+++ b/test/standard_api/controller/include_test.rb
@@ -50,6 +50,11 @@ class ControllerIncludesTest < ActionDispatch::IntegrationTest
   # end
 
   # = Including an invalid include
+  #
+  # These tests verify that invalid includes are rejected *before* the action
+  # persists any data. The `before_action :includes` on create, update, and
+  # create_resource validates includes early so that a bad request is returned
+  # without side effects.
 
   test "Controller#create with an invalid include" do
     property = build(:property)

--- a/test/standard_api/standard_api_test.rb
+++ b/test/standard_api/standard_api_test.rb
@@ -161,9 +161,8 @@ class PropertiesControllerTest < ActionDispatch::IntegrationTest
 
       model.columns.each do |column|
         assert_equal json_column_type(column.sql_type), schema.dig('models', model.name, 'attributes', column.name, 'type')
-        default = column.default
+        default = column_default_value(column, model)
         if !default.nil?
-          default = column.fetch_cast_type(model.connection).deserialize(default)
           assert_equal default, schema.dig('models', model.name, 'attributes', column.name, 'default')
         else
           assert_nil schema.dig('models', model.name, 'attributes', column.name, 'default')

--- a/test/standard_api/test_app.rb
+++ b/test/standard_api/test_app.rb
@@ -15,7 +15,7 @@ class TestApplication < Rails::Application
   config.root = File.join(File.dirname(__FILE__), 'test_app')
   config.secret_key_base = 'test key base'
   config.eager_load = true
-  config.cache_classes = true
+  config.enable_reloading = false
   config.action_controller.perform_caching = true
   config.cache_store = :memory_store, { size: 8.megabytes }
   config.action_dispatch.show_exceptions = :none


### PR DESCRIPTION
## Summary

- **Rails 8.2 compatibility**: Replace `Column#fetch_cast_type` (removed in 8.2) with version-branching via `respond_to?` since `cast_type` is protected in 8.1 but public in 8.2
- **Replace `ActiveSupport::Dependencies.constantize`** with `String#constantize` in schema views (removed on Rails main)
- **Fix `to_s(format)` → `to_fs(format)`** in cache key helper (deprecated since Rails 7.1)
- **Replace `config.cache_classes`** with `config.enable_reloading` in test app
- **Narrow `before_action :includes`** to only mutating actions (`create`, `update`, `create_resource`) — read-only actions don't need early include validation
- **Serialize BigDecimal as string** in both schema defaults (`column_default_value`) and record attributes (`serialize_attribute`) to preserve precision
- **Bump version to 8.2.0**
- **Add Rails main to CI matrix**
- **Minor cleanup**: Remove `send` for `include` calls in railtie

## Test plan

- [x] All 182 tests pass on Rails 8.1
- [ ] Verify tests pass on Rails main once CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)